### PR TITLE
Call dropBody from scope guard

### DIFF
--- a/src/octod/core.d
+++ b/src/octod/core.d
@@ -199,10 +199,12 @@ struct HTTPConnection
                 }
             );
 
+            scope(exit)
+                response.dropBody();
+
             if (auto location = this.handleResponseStatus(response))
             {
                 url = location;
-                response.dropBody();
                 continue;
             }
 
@@ -285,9 +287,11 @@ struct HTTPConnection
             }
         );
 
+        scope(exit)
+            response.dropBody();
+
         if (auto location = this.handleResponseStatus(response))
         {
-            response.dropBody();
             return this.post(location, json);
         }
 
@@ -322,9 +326,11 @@ struct HTTPConnection
             }
         );
 
+        scope(exit)
+            response.dropBody();
+
         if (auto location = this.handleResponseStatus(response))
         {
-            response.dropBody();
             return this.patch(location, json);
         }
 


### PR DESCRIPTION
Is more reliable than calling it manually as more code paths may be added
that affect it. As there is not situation when unready body should be
preserved by the end of helper method call, it can be dropped unconditionally.

I have actually one such code path when working on neptune and using this
PR fixes it fundamentally.