### PR TITLE
Pass connection wrapper around via pointer

### DIFF
--- a/src/octod/api/common.d
+++ b/src/octod/api/common.d
@@ -66,9 +66,9 @@ mixin template CommonEntityMethods ( )
 
     private
     {
-        HTTPConnection connection;
+        HTTPConnection* connection;
 
-        this ( HTTPConnection connection, const Json json )
+        this ( HTTPConnection* connection, const Json json )
         {
             this.json = json;
             this.connection = connection;

--- a/src/octod/api/issues.d
+++ b/src/octod/api/issues.d
@@ -69,7 +69,7 @@ struct Issue
     Returns:
         created issue
  **/
-Issue createIssue ( HTTPConnection connection, string repo, string title,
+Issue createIssue ( ref HTTPConnection connection, string repo, string title,
     string text, Json base = Json.emptyObject )
 {
     validateRepoString(repo);
@@ -78,7 +78,7 @@ Issue createIssue ( HTTPConnection connection, string repo, string title,
     base["body"]  = text;
 
     return Issue(
-        connection,
+        &connection,
         connection.post("/repos/" ~ repo ~ "/issues", base)
     );
 }
@@ -94,7 +94,7 @@ Issue createIssue ( HTTPConnection connection, string repo, string title,
         modificiations = json object with fields to modify, must comply to
             https://developer.github.com/v3/issues/#edit-an-issue
  **/
-void modifyIssue ( HTTPConnection connection, string repo, long number,
+void modifyIssue ( ref HTTPConnection connection, string repo, long number,
     Json modifications )
 {
     import std.format;
@@ -114,13 +114,13 @@ void modifyIssue ( HTTPConnection connection, string repo, long number,
             "sociomantic-tsunami/ocean"
         number = issue number to fetch
  **/
-Issue getIssue ( HTTPConnection connection, string repo, long number )
+Issue getIssue ( ref HTTPConnection connection, string repo, long number )
 {
     import std.format;
 
     validateRepoString(repo);
 
-    return Issue(connection,
+    return Issue(&connection,
         connection.get(format("/repos/%s/issues/%s", repo, number)));
 }
 
@@ -132,7 +132,7 @@ Issue getIssue ( HTTPConnection connection, string repo, long number )
         repo = repository string of form "owner/repo", for example
             "sociomantic-tsunami/ocean"
  **/
-Issue[] listIssues ( HTTPConnection connection, string repo )
+Issue[] listIssues ( ref HTTPConnection connection, string repo )
 {
     import std.format;
     import std.algorithm.iteration : map;
@@ -143,6 +143,6 @@ Issue[] listIssues ( HTTPConnection connection, string repo )
     return connection
         .get(format("/repos/%s/issues", repo))
         .get!(Json[])
-        .map!(element => Issue(connection, element))
+        .map!(element => Issue(&connection, element))
         .array();
 }

--- a/src/octod/api/projects.d
+++ b/src/octod/api/projects.d
@@ -42,7 +42,7 @@ enum ProjectMediaType = "application/vnd.github.inertia-preview+json";
     Returns:
         Array of project wrapper structs
  **/
-Project[] listOrganizationProjects ( HTTPConnection connection, string organization )
+Project[] listOrganizationProjects ( ref HTTPConnection connection, string organization )
 {
     import std.algorithm : map;
     import std.array : array;
@@ -52,7 +52,7 @@ Project[] listOrganizationProjects ( HTTPConnection connection, string organizat
     auto json = connection.get(url, ProjectMediaType);
     return json
         .get!(Json[])
-        .map!(json => Project(connection, json))
+        .map!(json => Project(&connection, json))
         .array();
 }
 
@@ -72,7 +72,7 @@ Project[] listOrganizationProjects ( HTTPConnection connection, string organizat
     Returns:
         wrapper struct for created project
  **/
-Project createOrganizationProject ( HTTPConnection connection,
+Project createOrganizationProject ( ref HTTPConnection connection,
     string organization, string name, string text = "" )
 {
     import std.format;
@@ -86,7 +86,7 @@ Project createOrganizationProject ( HTTPConnection connection,
         ])
     );
 
-    return Project(connection, json);
+    return Project(&connection, json);
 }
 
 /**
@@ -237,7 +237,7 @@ struct Column
     {
         import octod.api.issues : getIssue;
 
-        auto issue_id = this.connection.getIssue(repo, number).id();
+        auto issue_id = (*this.connection).getIssue(repo, number).id();
         return this.addCard(issue_id);
     }
 

--- a/src/octod/api/repos.d
+++ b/src/octod/api/repos.d
@@ -335,14 +335,14 @@ struct RepositoryEntity
     Returns:
         Wrapper struct to work with that repo embedding the json metadata
  **/
-Repository repository ( HTTPConnection connection, string repo )
+Repository repository ( ref HTTPConnection connection, string repo )
 {
     import std.format;
 
     validateRepoString(repo);
 
     return Repository(
-        connection,
+        &connection,
         connection.get(format("/repos/%s", repo))
     );
 }
@@ -359,7 +359,7 @@ Repository repository ( HTTPConnection connection, string repo )
     Returns:
         Array of json objects one per each repo
  **/
-Repository[] listOrganizationRepos ( HTTPConnection connection, string name,
+Repository[] listOrganizationRepos ( ref HTTPConnection connection, string name,
     string type = "sources" )
 {
     import std.format;
@@ -377,6 +377,6 @@ Repository[] listOrganizationRepos ( HTTPConnection connection, string name,
 
     return json
         .get!(Json[])
-        .map!(elem => Repository(connection, elem))
+        .map!(elem => Repository(&connection, elem))
         .array();
 }

--- a/src/octod/core.d
+++ b/src/octod/core.d
@@ -66,9 +66,7 @@ struct HTTPConnection
     private
     {
         alias Connection = typeof(connectHTTP(null, 0, false));
-
-        static assert (is(Connection == struct));
-        Connection* connection;
+        Connection connection;
 
         Configuration config;
     }
@@ -153,8 +151,7 @@ struct HTTPConnection
                 throw new HTTPAPIException("Protocol not supported: " ~ match[1]);
         }
 
-        this.connection = new Connection;
-        *this.connection = connectHTTP(addr, port, tls);
+        this.connection = connectHTTP(addr, port, tls);
 
         logTrace("Connected.");
     }


### PR DESCRIPTION
Fixes #14

There was a finalization race in octod previously as vibe.d requires for all
connections to be released before connection pool is finalized. But because
connection wrapper was GC allocated, order of finalization was not
determenistic.

Simply adding destructor to `HTTPConnection` was not possible because it is
passed around by copy in API modules. To make it work, API method were changed
to accept/capture `HTTPConnection` by reference/pointer instead.