### PR TITLE
Send custom media type with POST/PATCH too

### DIFF
--- a/src/octod/api/projects.d
+++ b/src/octod/api/projects.d
@@ -83,7 +83,8 @@ Project createOrganizationProject ( ref HTTPConnection connection,
         Json([
             "name" : Json(name),
             "body" : Json(text)
-        ])
+        ]),
+        ProjectMediaType
     );
 
     return Project(&connection, json);
@@ -165,7 +166,11 @@ struct Project
         import std.format;
 
         auto url = format("/projects/%s/columns", this.id());
-        auto json = connection.post(url, Json([ "name" : Json(name) ]));
+        auto json = connection.post(
+            url,
+            Json([ "name" : Json(name) ]),
+            ProjectMediaType
+        );
 
         return Column(connection, json);
     }
@@ -264,7 +269,8 @@ struct Column
                 Json([
                     "content_type" : Json("Issue"),
                     "content_id"   : Json(issue)
-                ])
+                ]),
+                ProjectMediaType
             )
         );
     }

--- a/src/octod/core.d
+++ b/src/octod/core.d
@@ -262,11 +262,12 @@ struct HTTPConnection
         Params:
             url = GitHub API method URL (relative)
             json = request body to send
+            accept = optional, request media type
 
         Returns:
             Json body of the response.
      **/
-    Json post ( string url, Json json )
+    Json post ( string url, Json json, MediaType accept )
     {
         assert (this.connection !is null);
 
@@ -279,7 +280,7 @@ struct HTTPConnection
             (scope request) {
                 request.requestURL = url;
                 request.method = HTTPMethod.POST;
-                this.prepareRequest(request);
+                this.prepareRequest(request, accept.toString());
                 request.writeJsonBody(json);
             }
         );
@@ -296,16 +297,26 @@ struct HTTPConnection
     }
 
     /**
+        ditto
+     **/
+    Json post ( string url, Json json, string accept = "")
+    {
+        return this.post(url, json, accept.length
+            ? MediaType.parse(accept) : MediaType.Default);
+    }
+
+    /**
         Sends PATCH request to API server
 
         Params:
             url = GitHub API method URL (relative)
             json = request body to send
+            accept = optional, request media type
 
         Returns:
             Json body of the response.
      **/
-    Json patch ( string url, Json json )
+    Json patch ( string url, Json json, MediaType accept )
     {
         assert (this.connection !is null);
 
@@ -318,7 +329,7 @@ struct HTTPConnection
             (scope request) {
                 request.requestURL = url;
                 request.method = HTTPMethod.PATCH;
-                this.prepareRequest(request);
+                this.prepareRequest(request, accept.toString());
                 request.writeJsonBody(json);
             }
         );
@@ -332,6 +343,15 @@ struct HTTPConnection
         }
 
         return response.readJson();
+    }
+
+    /**
+        ditto
+     **/
+    Json patch ( string url, Json json, string accept = "")
+    {
+        return this.post(url, json, accept.length
+            ? MediaType.parse(accept) : MediaType.Default);
     }
 
     /**

--- a/src/octod/core.d
+++ b/src/octod/core.d
@@ -382,7 +382,8 @@ struct HTTPConnection
 
         enforce!HTTPAPIException(
             status >= 200 && status < 300,
-            format("Expected status code 2xx, got %s", response.statusCode)
+            format("Expected status code 2xx, got %s\n\n%s\n",
+                response.statusCode, response.readJson())
         );
 
         return null;


### PR DESCRIPTION
GitHub API has changed since original introduction of this code and now
specifying "preview" media type is necessary to use any of project API.